### PR TITLE
Modify logging behavior when WP CLI is being used

### DIFF
--- a/stop-emails.php
+++ b/stop-emails.php
@@ -179,6 +179,10 @@ class Fe_Stop_Emails {
 		if ( ! $this->should_emails_be_logged_to_php_error_log() ) {
 			return;
 		}
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			WP_CLI::warning( 'Stop Emails: Not logging email to error log, because WP CLI is being used.' );
+			return;
+		}
 		$text = $this->mock_email_to_text( $mock_email );
 		error_log( $text );
 	}

--- a/stop-emails.php
+++ b/stop-emails.php
@@ -176,10 +176,11 @@ class Fe_Stop_Emails {
 	 * @since 0.8.0
 	 */
 	public function log_to_php_error_log( $mock_email ) {
-		if ( $this->should_emails_be_logged_to_php_error_log() ) {
-			$text = $this->mock_email_to_text( $mock_email );
-			error_log( $text );
+		if ( ! $this->should_emails_be_logged_to_php_error_log() ) {
+			return;
 		}
+		$text = $this->mock_email_to_text( $mock_email );
+		error_log( $text );
 	}
 
 	/**


### PR DESCRIPTION
This PR modifies logging to the error log when WP CLI is being used.

On the first pass, we're suppressing the email logging because when we write to the error log when using WP CLI it shows up in our on page output.

I'm not certain if this is the best solution.  I think ideally, even when using WP CLI, I'd like to write the stopped email information in the error log (but **not** output the stopped email on the command line).

Props @mitchelldmiller for bringing up the issue of the current behavior, which definitely needs to be improved.

See #15 