### PR TITLE
Update PHPMailer code in a backwards compatible way for WordPress 5.5

### DIFF
--- a/stop-emails.php
+++ b/stop-emails.php
@@ -19,8 +19,16 @@ if ( ! defined( 'WPINC' ) ) {
 
 register_deactivation_hook( __FILE__, array( 'Fe_Stop_Emails', 'on_deactivation' ) );
 
-// Load PHPMailer class, so we can subclass it.
-class Fe_Stop_Emails_PHPMailer extends PHPMailer {}
+if ( Fe_Stop_Emails::is_pre_wp_5_5() ) {
+	// Legacy: Load PHPMailer class, so we can subclass it.
+	require_once ABSPATH . WPINC . '/class-phpmailer.php';
+	class Fe_Stop_Emails_PHPMailer extends PHPMailer {}
+} else {
+	// Modern: Load PHPMailer class, so we can subclass it.
+	require_once ABSPATH . WPINC . '/PHPMailer/PHPMailer.php';
+	require_once ABSPATH . WPINC . '/PHPMailer/Exception.php';
+	class Fe_Stop_Emails_PHPMailer extends PHPMailer\PHPMailer\PHPMailer {}
+}
 
 /**
  * Subclass of PHPMailer to prevent Sending.

--- a/stop-emails.php
+++ b/stop-emails.php
@@ -20,7 +20,7 @@ if ( ! defined( 'WPINC' ) ) {
 register_deactivation_hook( __FILE__, array( 'Fe_Stop_Emails', 'on_deactivation' ) );
 
 // Load PHPMailer class, so we can subclass it.
-require_once ABSPATH . WPINC . '/class-phpmailer.php';
+class Fe_Stop_Emails_PHPMailer extends PHPMailer {}
 
 /**
  * Subclass of PHPMailer to prevent Sending.
@@ -33,7 +33,7 @@ require_once ABSPATH . WPINC . '/class-phpmailer.php';
  * @since 0.8.0
  * @see PHPMailer
  */
-class Fe_Stop_Emails_Fake_PHPMailer extends PHPMailer {
+class Fe_Stop_Emails_Fake_PHPMailer extends Fe_Stop_Emails_PHPMailer {
 	/**
 	 * Mock sent email.
 	 *

--- a/stop-emails.php
+++ b/stop-emails.php
@@ -283,6 +283,16 @@ class Fe_Stop_Emails {
 	public static function on_deactivation() {
 		delete_option( 'fe_stop_emails_options' );
 	}
+
+	/**
+	 * WordPress core version is less than 5.5
+	 *
+	 * @since 1.3.0
+	 * @return bool WordPress core version is less than 5.5
+	 */
+	public static function is_pre_wp_5_5() {
+		return version_compare( get_bloginfo( 'version' ), '5.5-alpha', '<' );
+	}
 }
 
 new Fe_Stop_Emails;


### PR DESCRIPTION
Based on the [changes in how PHPMailer is loaded](https://github.com/salcode/stop-emails/issues/18#issuecomment-660659557) (and namespaced) starting in WordPress core 5.5 we:

- add a WordPress core version check
- based on the WordPress core version, load PHPMailer in the appropriate way
- create a new intermediary class (`Fe_Stop_Emails_PHPMailer`) that extends PHPMailer (this intermediary class extends either `PHPMailer` or `PHPMailer\PHPMailer\PHPMailer` depending on the WordPress core version)
- use the new intermediary class to create our fake mailer class (`Fe_Stop_Emails_Fake_PHPMailer`)

See #18 